### PR TITLE
aws-iam-db 0.0.5: action-level condition keys + resilient action scraper

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Run tests
+        run: uv run --with pytest pytest tests/ -q

--- a/aws_iam_db/build_db.py
+++ b/aws_iam_db/build_db.py
@@ -28,6 +28,27 @@ resource_condition_table = Table(
     Column("condition_id", Integer, ForeignKey("condition.id")),
 )
 
+# Condition keys that AWS documents for an action itself. AWS lists condition
+# keys per (action, resource type) row in the "Actions" table; the union of
+# those keys is the set usable with the action. This is distinct from
+# `resource_condition`, which records the keys a *resource type* supports. Some
+# actions (e.g. acm:RequestCertificate) operate on no resource type at all and
+# carry their keys on a blank-resource-type row, so without this table those
+# keys would be dropped entirely.
+action_condition_table = Table(
+    "action_condition",
+    Base.metadata,
+    Column("action_id", Integer, ForeignKey("action.id")),
+    Column("condition_id", Integer, ForeignKey("condition.id")),
+)
+
+
+def normalize_condition_key(key: str) -> str:
+    """Collapse all whitespace out of a condition key so keys scraped from the
+    Actions table (which only collapses runs of whitespace) line up with the
+    same keys scraped from the condition-keys table (which strips it all)."""
+    return "".join(str(key).split())
+
 
 class DependentAction(Base):
     """SQLAlchemy Declarative configuration for the Dependent Actions table"""
@@ -56,6 +77,7 @@ class Action(Base):
     access_level = Column(String(), index=True)
     resources = relationship("Resource", secondary=action_resource_table)
     dependent_actions = relationship("DependentAction")
+    condition_keys = relationship("Condition", secondary=action_condition_table)
 
     def __repr__(self):
         return "<Action(name='%s', description='%s', access_level='%s')>" % (
@@ -118,6 +140,10 @@ def create_database(db_session: Session, json_data: list):
 
             # Create conditions first
             condition_map = {}  # Cache conditions to avoid duplicates
+            # Same conditions keyed by their whitespace-normalized name, so the
+            # keys listed against actions can be matched even if their spacing
+            # differs from the condition-keys table.
+            normalized_condition_map = {}
             for cond in row["conditions"]:
                 condition_key = cond["condition"]
                 if condition_key not in condition_map:
@@ -128,6 +154,9 @@ def create_database(db_session: Session, json_data: list):
                     )
                     db_session.add(new_cond)
                     condition_map[condition_key] = new_cond
+                    normalized_condition_map[normalize_condition_key(condition_key)] = (
+                        new_cond
+                    )
 
             # Create resources for this service
             resource_map = {}  # Cache resources to avoid duplicates
@@ -170,12 +199,36 @@ def create_database(db_session: Session, json_data: list):
                         for act in res_type["dependent_actions"]
                     ])
 
+                # Collect the condition keys AWS documents for this action: the
+                # union across every resource-type row, including a row with no
+                # resource type (where action-level keys live). Matching through
+                # the resource types alone would miss those keys.
+                action_conditions = []
+                seen_condition_keys = set()
+                for res_type in priv["resource_types"]:
+                    for key in res_type["condition_keys"]:
+                        normalized_key = normalize_condition_key(key)
+                        if not normalized_key or normalized_key in seen_condition_keys:
+                            continue
+                        seen_condition_keys.add(normalized_key)
+                        condition = normalized_condition_map.get(normalized_key)
+                        if condition is None:
+                            # The Actions table referenced a key the service's
+                            # condition-keys table didn't list; keep it anyway so
+                            # the association is complete.
+                            condition = Condition(name=key, description="", type="")
+                            db_session.add(condition)
+                            condition_map[key] = condition
+                            normalized_condition_map[normalized_key] = condition
+                        action_conditions.append(condition)
+
                 new_priv = Action(
                     name=f"{service_name}:{priv['privilege']}",
                     description=priv["description"],
                     access_level=priv["access_level"],
                     resources=matching_resources,
                     dependent_actions=dep_actions,
+                    condition_keys=action_conditions,
                 )
                 db_session.add(new_priv)
 

--- a/tests/test_build_db.py
+++ b/tests/test_build_db.py
@@ -1,0 +1,161 @@
+"""Tests for the action -> condition-key association added to the schema.
+
+AWS documents condition keys per (action, resource type) row in its "Actions"
+table. Some actions operate on no resource type (e.g. acm:RequestCertificate)
+and carry their condition keys on a blank-resource-type row, so the keys have to
+be read from the action rows directly rather than through resource types.
+"""
+
+from sqlalchemy import text
+
+from aws_iam_db.build_db import Base, connect, create_database, normalize_condition_key
+
+
+# A single-service fixture shaped exactly like the scraper's JSON output. The
+# ACM "RequestCertificate" action deliberately has an empty resource type, which
+# is where its action-level condition keys live.
+ACM_FIXTURE = [
+    {
+        "service_name": "AWS Certificate Manager",
+        "prefix": "acm",
+        "conditions": [
+            {"condition": "acm:DomainNames", "description": "domains", "type": "ArrayOfString"},
+            {"condition": "acm:ValidationMethod", "description": "validation", "type": "String"},
+            {"condition": "acm:KeyAlgorithm", "description": "algorithm", "type": "String"},
+            {"condition": "aws:RequestTag/${TagKey}", "description": "request tag", "type": "String"},
+            {"condition": "aws:TagKeys", "description": "tag keys", "type": "ArrayOfString"},
+            {"condition": "aws:ResourceTag/${TagKey}", "description": "resource tag", "type": "String"},
+        ],
+        "resources": [
+            {
+                "resource": "certificate",
+                "arn": "arn:${Partition}:acm:${Region}:${Account}:certificate/${CertificateId}",
+                "condition_keys": ["aws:ResourceTag/${TagKey}"],
+            }
+        ],
+        "privileges": [
+            {
+                "privilege": "RequestCertificate",
+                "description": "Request a certificate",
+                "access_level": "Write",
+                "resource_types": [
+                    {
+                        "resource_type": "",
+                        "condition_keys": [
+                            "acm:DomainNames",
+                            "acm:ValidationMethod",
+                            "acm:KeyAlgorithm",
+                            "aws:RequestTag/${TagKey}",
+                            "aws:TagKeys",
+                        ],
+                        "dependent_actions": [],
+                    }
+                ],
+            },
+            {
+                "privilege": "AddTagsToCertificate",
+                "description": "Add tags",
+                "access_level": "Tagging",
+                "resource_types": [
+                    {
+                        "resource_type": "certificate",
+                        "condition_keys": ["aws:RequestTag/${TagKey}", "aws:TagKeys"],
+                        "dependent_actions": [],
+                    }
+                ],
+            },
+            {
+                "privilege": "DescribeCertificate",
+                "description": "Describe a certificate",
+                "access_level": "Read",
+                "resource_types": [
+                    {"resource_type": "certificate", "condition_keys": [], "dependent_actions": []}
+                ],
+            },
+            {
+                # Exercises a condition key referenced by an action but missing
+                # from the service's condition-keys table.
+                "privilege": "ImportCertificate",
+                "description": "Import a certificate",
+                "access_level": "Write",
+                "resource_types": [
+                    {
+                        "resource_type": "certificate",
+                        "condition_keys": ["aws:UnlistedKey"],
+                        "dependent_actions": [],
+                    }
+                ],
+            },
+        ],
+    }
+]
+
+
+def _build(tmp_path):
+    session, engine = connect(str(tmp_path / "iam.db"))
+    Base.metadata.create_all(engine)
+    create_database(session, ACM_FIXTURE)
+    return session
+
+
+def _condition_keys(session, action_name):
+    rows = session.execute(
+        text(
+            """
+            SELECT c.name
+            FROM action a
+            JOIN action_condition ac ON ac.action_id = a.id
+            JOIN condition c ON c.id = ac.condition_id
+            WHERE a.name = :name
+            ORDER BY c.name
+            """
+        ),
+        {"name": action_name},
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def test_action_condition_table_exists(tmp_path):
+    session = _build(tmp_path)
+    exists = session.execute(
+        text("SELECT name FROM sqlite_master WHERE type='table' AND name='action_condition'")
+    ).fetchone()
+    assert exists is not None
+
+
+def test_resourceless_action_keeps_action_level_keys(tmp_path):
+    # The regression this whole change is about: an action with no resource type
+    # must still expose its condition keys.
+    session = _build(tmp_path)
+    assert _condition_keys(session, "acm:RequestCertificate") == [
+        "acm:DomainNames",
+        "acm:KeyAlgorithm",
+        "acm:ValidationMethod",
+        "aws:RequestTag/${TagKey}",
+        "aws:TagKeys",
+    ]
+
+
+def test_resource_scoped_action_uses_actions_table_keys(tmp_path):
+    # Keys come from the action's own row, not from every key the resource
+    # supports (the certificate resource also supports aws:ResourceTag).
+    session = _build(tmp_path)
+    assert _condition_keys(session, "acm:AddTagsToCertificate") == [
+        "aws:RequestTag/${TagKey}",
+        "aws:TagKeys",
+    ]
+
+
+def test_action_without_condition_keys_has_none(tmp_path):
+    session = _build(tmp_path)
+    assert _condition_keys(session, "acm:DescribeCertificate") == []
+
+
+def test_key_absent_from_conditions_table_is_still_linked(tmp_path):
+    session = _build(tmp_path)
+    assert _condition_keys(session, "acm:ImportCertificate") == ["aws:UnlistedKey"]
+
+
+def test_normalize_condition_key():
+    assert normalize_condition_key("aws:RequestTag/${TagKey}") == "aws:RequestTag/${TagKey}"
+    assert normalize_condition_key("aws: TagKeys ") == "aws:TagKeys"


### PR DESCRIPTION
Release **0.0.5**. Two fixes plus a test suite and CI.

## 1. Scraper no longer drops a tail of actions (`docs.py`)

AWS lists actions alphabetically in the "Actions" table. The parser aborted the **whole** table on the first row that didn't have six columns (`if len(cells) != 6: break`), silently dropping that action **and every action listed after it**. When AWS recently added new **ACME** actions to the ACM page (`CreateAcmeEndpoint`, `CreateAcmeDomainValidation`, …), this started dropping `acm:RequestCertificate` and the actions after it from the database — which is why they disappeared from awsiam.info.

Fix: skip the offending row and keep parsing. Regression test added (`tests/test_docs.py`) proving a malformed middle row no longer drops a following action. Verified against a full 532-service snapshot: still 23,300 actions parsed (no regression).

## 2. Action-level condition keys are stored (`build_db.py`)

Condition keys were only linked to resource types, so actions with no resource type (e.g. `acm:RequestCertificate`) lost their keys (`acm:DomainNames`, …). Adds an `action_condition` association table populated with the union of each action's condition keys across all its resource-type rows.

## Tests / CI

- `tests/test_build_db.py` — 6 tests for the association (resource-less action, resource-scoped action, no-keys, unlisted-key fallback, normalizer).
- `tests/test_docs.py` — scraper resilience regression test.
- `.github/workflows/tests.yaml` — runs `pytest` on push/PR. All 7 tests pass.

## Version

Bumped to `0.0.5` (PyPI latest is 0.0.4). Publishing requires pushing a `v0.0.5` tag (the `publish.yaml` workflow triggers on `v*` tags).

## Downstream (aws-iam-cloudflare)

Once 0.0.5 is published and the site's DB rebuilds with it, `acm:RequestCertificate` returns (scraper fix). A separate downstream change to `post_export.sql` (read condition keys via `action → action_condition → condition`) will then surface the keys.